### PR TITLE
Desafio 1 dos editais 12 e 13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 .classpath
 .project
 .settings
+.iml
+.idea
 prepros.cfg
 db.backup.gz

--- a/src/main/java/br/gov/mj/sislegis/app/parser/senado/ParserProposicaoSenado.java
+++ b/src/main/java/br/gov/mj/sislegis/app/parser/senado/ParserProposicaoSenado.java
@@ -9,73 +9,86 @@ import java.util.List;
 import java.util.Objects;
 
 public class ParserProposicaoSenado {
-	
+
 	public static void main(String[] args) throws Exception {
 		ParserProposicaoSenado parser = new ParserProposicaoSenado();
 		Long idProposicao = 24257L; // TODO: Informação que vem do filtro
 		System.out.println(parser.getProposicao(idProposicao).toString());
 	}
-	
+
 	public Proposicao getProposicao(Long idProposicao) throws Exception {
-		String wsURL = "http://legis.senado.leg.br/dadosabertos/materia/"+idProposicao+"?v=3";
+		String wsURL = "http://legis.senado.leg.br/dadosabertos/materia/" + idProposicao + "?v=3";
 		URL url = new URL(wsURL);
-		
+
 		XStream xstream = new XStream();
 		xstream.ignoreUnknownElements();
-		
+
 		DetalheMateria detalheMateria = new DetalheMateria();
-		
+
 		config(xstream);
 
 		xstream.fromXML(url, detalheMateria);
-		
-		Proposicao proposicao = new ProposicaoSenado();
-		
-		proposicao = detalheMateria.getProposicoes().isEmpty() ? proposicao : detalheMateria.getProposicoes().get(0);
+
+		Proposicao proposicao = new Proposicao();
+
+		proposicao = detalheMateria.getProposicoes().isEmpty() ? proposicao : detalheMateria.getProposicoes().get(0).converterParaProposicao();
 		proposicao.setOrigem(Origem.SENADO);
-		proposicao.setLinkProposicao("http://www.senado.leg.br/atividade/materia/detalhes.asp?p_cod_mate="+proposicao.getIdProposicao());
-		
+		proposicao.setLinkProposicao("http://www.senado.leg.br/atividade/materia/detalhes.asp?p_cod_mate=" + proposicao.getIdProposicao());
+
 		return proposicao;
 	}
-	
+
 	private static void config(XStream xstream) {
 		xstream.alias("DetalheMateria", DetalheMateria.class);
-		xstream.alias("Materia", ProposicaoSenado.class);
+		xstream.alias("Materia", ProposicaoSenadoDTO.class);
 		xstream.alias("Autor", Autor.class);
 
 		xstream.aliasField("Materias", DetalheMateria.class, "proposicoes");
-		xstream.aliasField("Autoria", ProposicaoSenado.class, "autores");
+		xstream.aliasField("Autoria", ProposicaoSenadoDTO.class, "autores");
 
-		xstream.aliasField("Codigo", ProposicaoSenado.class, "idProposicao");
-		xstream.aliasField("Subtipo", ProposicaoSenado.class, "tipo");
-		xstream.aliasField("Numero", ProposicaoSenado.class, "numero");
-		xstream.aliasField("Ano", ProposicaoSenado.class, "ano");
-		xstream.aliasField("Ementa", ProposicaoSenado.class, "ementa");
+		xstream.aliasField("Codigo", ProposicaoSenadoDTO.class, "idProposicao");
+		xstream.aliasField("Subtipo", ProposicaoSenadoDTO.class, "tipo");
+		xstream.aliasField("Numero", ProposicaoSenadoDTO.class, "numero");
+		xstream.aliasField("Ano", ProposicaoSenadoDTO.class, "ano");
+		xstream.aliasField("Ementa", ProposicaoSenadoDTO.class, "ementa");
 		xstream.aliasField("Nome", Autor.class, "nome");
-
 	}
+
 }
 
 class DetalheMateria {
 
-	protected List<ProposicaoSenado> proposicoes;
+	protected List<ProposicaoSenadoDTO> proposicoes;
 
-	protected List<ProposicaoSenado> getProposicoes() {
+	protected List<ProposicaoSenadoDTO> getProposicoes() {
 		return proposicoes;
 	}
 }
 
-class ProposicaoSenado extends Proposicao {
+class ProposicaoSenadoDTO {
+	protected Integer idProposicao;
+	protected String tipo;
+	protected String numero;
+	protected String ano;
+	protected String ementa;
 	protected List<Autor> autores;
 
-	protected List<Autor> getAutores() {
-		return autores;
+	protected Proposicao converterParaProposicao() {
+		Proposicao proposicao = new Proposicao();
+		proposicao.setIdProposicao(idProposicao);
+		proposicao.setTipo(tipo);
+		proposicao.setNumero(numero);
+		proposicao.setAno(ano);
+		proposicao.setEmenta(ementa);
+
+		proposicao.setAutor(converterAutorUnico());
+
+		return proposicao;
 	}
 
-	@Override
-	public String getAutor() {
+	private String converterAutorUnico() {
 		if (Objects.isNull(autores) || autores.size() == 0) {
-			return super.getAutor();
+			return null;
 
 		} else {
 			return autores.get(0).getNome();

--- a/src/main/java/br/gov/mj/sislegis/app/parser/senado/ParserProposicaoSenado.java
+++ b/src/main/java/br/gov/mj/sislegis/app/parser/senado/ParserProposicaoSenado.java
@@ -87,7 +87,7 @@ class ProposicaoSenadoDTO {
 	}
 
 	private String converterAutorUnico() {
-		if (Objects.isNull(autores) || autores.size() == 0) {
+		if (Objects.isNull(autores) || autores.isEmpty()) {
 			return null;
 
 		} else {

--- a/src/main/java/br/gov/mj/sislegis/app/parser/senado/ParserProposicaoSenado.java
+++ b/src/main/java/br/gov/mj/sislegis/app/parser/senado/ParserProposicaoSenado.java
@@ -1,12 +1,12 @@
 package br.gov.mj.sislegis.app.parser.senado;
 
-import java.net.URL;
-import java.util.List;
-
 import br.gov.mj.sislegis.app.enumerated.Origem;
 import br.gov.mj.sislegis.app.model.Proposicao;
-
 import com.thoughtworks.xstream.XStream;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Objects;
 
 public class ParserProposicaoSenado {
 	
@@ -29,7 +29,7 @@ public class ParserProposicaoSenado {
 
 		xstream.fromXML(url, detalheMateria);
 		
-		Proposicao proposicao = new Proposicao();
+		Proposicao proposicao = new ProposicaoSenado();
 		
 		proposicao = detalheMateria.getProposicoes().isEmpty() ? proposicao : detalheMateria.getProposicoes().get(0);
 		proposicao.setOrigem(Origem.SENADO);
@@ -40,23 +40,55 @@ public class ParserProposicaoSenado {
 	
 	private static void config(XStream xstream) {
 		xstream.alias("DetalheMateria", DetalheMateria.class);
-		xstream.alias("Materia", Proposicao.class);
-		
+		xstream.alias("Materia", ProposicaoSenado.class);
+		xstream.alias("Autor", Autor.class);
+
 		xstream.aliasField("Materias", DetalheMateria.class, "proposicoes");
-		
-		xstream.aliasField("Codigo", Proposicao.class, "idProposicao");
-		xstream.aliasField("Subtipo", Proposicao.class, "tipo");
-		xstream.aliasField("Numero", Proposicao.class, "numero");
-		xstream.aliasField("Ano", Proposicao.class, "ano");
-		xstream.aliasField("Ementa", Proposicao.class, "ementa");
+		xstream.aliasField("Autoria", ProposicaoSenado.class, "autores");
+
+		xstream.aliasField("Codigo", ProposicaoSenado.class, "idProposicao");
+		xstream.aliasField("Subtipo", ProposicaoSenado.class, "tipo");
+		xstream.aliasField("Numero", ProposicaoSenado.class, "numero");
+		xstream.aliasField("Ano", ProposicaoSenado.class, "ano");
+		xstream.aliasField("Ementa", ProposicaoSenado.class, "ementa");
+		xstream.aliasField("Nome", Autor.class, "nome");
+
 	}
 }
 
 class DetalheMateria {
 
-	protected List<Proposicao> proposicoes;
+	protected List<ProposicaoSenado> proposicoes;
 
-	protected List<Proposicao> getProposicoes() {
+	protected List<ProposicaoSenado> getProposicoes() {
 		return proposicoes;
+	}
+}
+
+class ProposicaoSenado extends Proposicao {
+	protected List<Autor> autores;
+
+	protected List<Autor> getAutores() {
+		return autores;
+	}
+
+	@Override
+	public String getAutor() {
+		if (Objects.isNull(autores) || autores.size() == 0) {
+			return super.getAutor();
+
+		} else {
+			return autores.get(0).getNome();
+		}
+
+	}
+
+}
+
+class Autor {
+	protected String nome;
+
+	protected String getNome() {
+		return nome;
 	}
 }


### PR DESCRIPTION
Exibindo autor para as proposições retornadas pelo serviço do Senado.
Foi criado em ParserProposicaoSenado um DTO para a proposição, para se adequar ao formato do XML retornado pelo serviço do Senado, onde o autor possui outros campos além do nome, e ainda está agrupado em Autorias, sugerindo que pode existir mais de um autor.
Futuramente pode-se melhorar o código para exibir mais de um autor, caso seja confirmada esta possibilidade nos retornos do web service do Senado.