### PR TITLE
Fix abstract entity

### DIFF
--- a/src/main/java/br/gov/mj/sislegis/app/model/AbstractEntity.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/AbstractEntity.java
@@ -8,12 +8,43 @@ import java.io.Serializable;
  * @author raphael.santos
  *
  */
-public interface AbstractEntity extends Serializable {
+public abstract class AbstractEntity implements Serializable {
 
 	/**
-	 * @return A referencia para a chave primaria (Primary Key) de cada objeto persistido.
-	 * 		   Caso o objeto ainda não tenha sido persistido, deve retornar <code>null</code>.
+	 * 
 	 */
-	public Number getId();
-	
+	private static final long serialVersionUID = 8805686324493542628L;
+
+	/**
+	 * @return A referencia para a chave primaria (Primary Key) de cada objeto
+	 *         persistido. Caso o objeto ainda não tenha sido persistido, deve
+	 *         retornar <code>null</code>.
+	 */
+	public abstract Number getId();
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj.getClass().equals(this.getClass())) || !(obj instanceof AbstractEntity)) {
+			return false;
+		}
+		AbstractEntity other = (AbstractEntity) obj;
+		if (getId() != null) {
+			if (!getId().equals(other.getId())) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((getId() == null) ? 0 : getId().hashCode());
+		return result;
+	}
+
 }

--- a/src/main/java/br/gov/mj/sislegis/app/model/AbstractEntity.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/AbstractEntity.java
@@ -24,6 +24,9 @@ public abstract class AbstractEntity implements Serializable {
 
 	@Override
 	public boolean equals(Object obj) {
+		if (obj == null) {
+			return false;
+		}
 		if (this == obj) {
 			return true;
 		}
@@ -31,19 +34,18 @@ public abstract class AbstractEntity implements Serializable {
 			return false;
 		}
 		AbstractEntity other = (AbstractEntity) obj;
-		if (getId() != null) {
-			if (!getId().equals(other.getId())) {
-				return false;
-			}
+		if (getId() == null) {
+			return false;
+		} else {
+			return getId().equals(other.getId());
 		}
-		return true;
 	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((getId() == null) ? 0 : getId().hashCode());
+		result = prime * result + ((getId() == null) ? super.hashCode() : getId().hashCode());
 		return result;
 	}
 

--- a/src/main/java/br/gov/mj/sislegis/app/model/AreaConsultada.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/AreaConsultada.java
@@ -11,7 +11,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
 @XmlRootElement
-public class AreaConsultada implements AbstractEntity {
+public class AreaConsultada extends AbstractEntity {
 
 	private static final long serialVersionUID = -2801342641242367391L;
 
@@ -34,30 +34,7 @@ public class AreaConsultada implements AbstractEntity {
 		this.id = id;
 	}
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof AreaConsultada)) {
-			return false;
-		}
-		AreaConsultada other = (AreaConsultada) obj;
-		if (id != null) {
-			if (!id.equals(other.id)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
-	}
+	
 
 	public String getDescricao() {
 		return descricao;

--- a/src/main/java/br/gov/mj/sislegis/app/model/Comentario.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/Comentario.java
@@ -16,19 +16,18 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-
 @Entity
 @XmlRootElement
-@JsonIgnoreProperties({"idProposicao"})
-public class Comentario implements AbstractEntity {
-
+@JsonIgnoreProperties({ "idProposicao" })
+public class Comentario extends AbstractEntity {
+	
 	private static final long serialVersionUID = 739840933885769688L;
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "id", updatable = false, nullable = false)
 	private Long id;
 
-	@Column(length=8000)
+	@Column(length = 8000)
 	private String descricao;
 
 	@ManyToOne(fetch = FetchType.EAGER)
@@ -41,38 +40,12 @@ public class Comentario implements AbstractEntity {
 	@ManyToOne(fetch = FetchType.EAGER)
 	private Proposicao proposicao;
 
-
 	public Long getId() {
 		return this.id;
 	}
 
 	public void setId(final Long id) {
 		this.id = id;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof Comentario)) {
-			return false;
-		}
-		Comentario other = (Comentario) obj;
-		if (id != null) {
-			if (!id.equals(other.id)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
 	}
 
 	public String getDescricao() {
@@ -110,7 +83,7 @@ public class Comentario implements AbstractEntity {
 	}
 
 	public Proposicao getProposicao() {
-		if(!Objects.isNull(this.proposicao)){
+		if (!Objects.isNull(this.proposicao)) {
 			Proposicao p = new Proposicao();
 			p.setId(proposicao.getId());
 			this.proposicao = p;

--- a/src/main/java/br/gov/mj/sislegis/app/model/Comissao.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/Comissao.java
@@ -9,7 +9,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
 @XmlRootElement
-public class Comissao implements AbstractEntity {
+public class Comissao extends AbstractEntity {
 
 	private static final long serialVersionUID = -9103342334603175569L;
 
@@ -45,28 +45,4 @@ public class Comissao implements AbstractEntity {
 		return result;
 	}
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof Comissao)) {
-			return false;
-		}
-		Comissao other = (Comissao) obj;
-		if (id != null) {
-			if (!id.equals(other.id)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
-	}
 }

--- a/src/main/java/br/gov/mj/sislegis/app/model/ElaboracaoNormativa.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/ElaboracaoNormativa.java
@@ -38,227 +38,230 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 @XmlRootElement
 @Table(name = "elaboracao_normativa")
 @JsonIdentityReference(alwaysAsId = true)
-public class ElaboracaoNormativa implements AbstractEntity  {
-	
+public class ElaboracaoNormativa extends AbstractEntity {
+
 	private static final long serialVersionUID = 7722617248451501605L;
-	
+
 	public ElaboracaoNormativa() {
 	}
-	
 
-	public ElaboracaoNormativa(Long id, ElaboracaoNormativaTipo tipo, ElaboracaoNormativaSubTipo subTipo, 
+	public ElaboracaoNormativa(Long id, ElaboracaoNormativaTipo tipo, ElaboracaoNormativaSubTipo subTipo,
 			ElaboracaoNormativaSituacao elaboracaoNormativaSituacao, ElaboracaoNormativaNorma elaboracaoNormativaNorma,
-			Integer ano, String numero,
-			String origemDescricao, String coAutores, String ementa,
-			String statusSidof, ElaboracaoNormativaObjeto identificacao,
-			String equipe, String parecerista, String nup, Date dataInclusaoSIDOF, Date dataAssinaturaSIDOF,
-			String ementaManifestacao, Date dataManifestacao, Integer normaGeradaAno, String normaGeradaNumero) {
-		this.id=id;
-		this.valueTipoSubTipo=Objects.isNull(tipo)?"":tipo.getValue()+" "+(Objects.isNull(subTipo)?"":subTipo.getValue());
-		this.situacaoDescricao=Objects.isNull(elaboracaoNormativaSituacao)?"":elaboracaoNormativaSituacao.getValue();
-		this.tipoNormaDescricao=Objects.isNull(elaboracaoNormativaNorma)?"":elaboracaoNormativaNorma.getValue();
-		this.ano=ano;
-		this.numero=numero;
-		this.origemDescricao=origemDescricao;
-		this.coAutoresDescricao=coAutores;
-		this.ementa=ementa;
-		this.statusSidofDescricao=statusSidof;
-		this.identificacao=identificacao;
-		this.valueIdentificacao=Objects.isNull(identificacao)?null:identificacao.getValue();
-		this.equipeDescricao=equipe;
-		this.pareceristaDescricao=parecerista;
-		this.nup=nup;
-		this.dataInclusaoSIDOFFormatada=Objects.isNull(dataInclusaoSIDOF)?"":Conversores.dateToString(dataInclusaoSIDOF);
-		this.dataAssinaturaSIDOFFormatada=Objects.isNull(dataAssinaturaSIDOF)?"":Conversores.dateToString(dataAssinaturaSIDOF);
-		this.ementaManifestacao=ementaManifestacao;
-		this.dataMinifestacaoFormatada=Objects.isNull(dataManifestacao)?"":Conversores.dateToString(dataManifestacao);
-		this.normaGeradaAno=normaGeradaAno;
-		this.normaGeradaNumero=normaGeradaNumero;
+			Integer ano, String numero, String origemDescricao, String coAutores, String ementa, String statusSidof,
+			ElaboracaoNormativaObjeto identificacao, String equipe, String parecerista, String nup,
+			Date dataInclusaoSIDOF, Date dataAssinaturaSIDOF, String ementaManifestacao, Date dataManifestacao,
+			Integer normaGeradaAno, String normaGeradaNumero) {
+		this.id = id;
+		this.valueTipoSubTipo = Objects.isNull(tipo) ? "" : tipo.getValue() + " "
+				+ (Objects.isNull(subTipo) ? "" : subTipo.getValue());
+		this.situacaoDescricao = Objects.isNull(elaboracaoNormativaSituacao) ? "" : elaboracaoNormativaSituacao
+				.getValue();
+		this.tipoNormaDescricao = Objects.isNull(elaboracaoNormativaNorma) ? "" : elaboracaoNormativaNorma.getValue();
+		this.ano = ano;
+		this.numero = numero;
+		this.origemDescricao = origemDescricao;
+		this.coAutoresDescricao = coAutores;
+		this.ementa = ementa;
+		this.statusSidofDescricao = statusSidof;
+		this.identificacao = identificacao;
+		this.valueIdentificacao = Objects.isNull(identificacao) ? null : identificacao.getValue();
+		this.equipeDescricao = equipe;
+		this.pareceristaDescricao = parecerista;
+		this.nup = nup;
+		this.dataInclusaoSIDOFFormatada = Objects.isNull(dataInclusaoSIDOF) ? "" : Conversores
+				.dateToString(dataInclusaoSIDOF);
+		this.dataAssinaturaSIDOFFormatada = Objects.isNull(dataAssinaturaSIDOF) ? "" : Conversores
+				.dateToString(dataAssinaturaSIDOF);
+		this.ementaManifestacao = ementaManifestacao;
+		this.dataMinifestacaoFormatada = Objects.isNull(dataManifestacao) ? "" : Conversores
+				.dateToString(dataManifestacao);
+		this.normaGeradaAno = normaGeradaAno;
+		this.normaGeradaNumero = normaGeradaNumero;
 	}
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "id", updatable = false, nullable = false)
 	private Long id;
-	
+
 	// Dados preliminares
-	
+
 	@Column
 	private Date dataRegistro;
-	
+
 	@Column
 	@Enumerated(EnumType.ORDINAL)
 	private ElaboracaoNormativaTipo tipo;
-	
+
 	@Column
 	@Enumerated(EnumType.ORDINAL)
-	private ElaboracaoNormativaSubTipo subTipo;	
-	
+	private ElaboracaoNormativaSubTipo subTipo;
+
 	@Transient
 	private List<ElaboracaoNormativaTipo> tipos;
 
 	@Transient
 	private List<ElaboracaoNormativaSubTipo> subTipos;
-	
+
 	@Transient
 	private String valueTipo;
-	
+
 	@Column
 	private String nup;
-	
+
 	@Column
 	@Enumerated(EnumType.ORDINAL)
 	private ElaboracaoNormativaObjeto identificacao;
-	
+
 	@Transient
 	private String valueIdentificacao;
-	
+
 	@Transient
 	private String valueTipoSubTipo;
 
 	@ManyToOne(fetch = FetchType.EAGER)
 	private Orgao coAutor;
-	
-	
+
 	@ManyToOne(fetch = FetchType.EAGER)
 	private Orgao origem;
 
 	@JsonIgnore
 	@ManyToOne(fetch = FetchType.EAGER)
 	private AreaConsultada areaConsultada;
-	
+
 	@Column
 	private String ementa;
-	
+
 	// TODO: tags
-	
+
 	// Dados de análise e distribuição
 	@Column
 	private Date dataDistribuicao;
-	
+
 	@ManyToOne(fetch = FetchType.EAGER)
 	private Equipe equipe;
-	
+
 	@ManyToOne(fetch = FetchType.EAGER)
 	private Usuario parecerista;
 
 	@OneToMany(cascade = CascadeType.ALL, mappedBy = "elaboracaoNormativa", fetch = FetchType.EAGER)
 	private List<ElaboracaoNormativaConsulta> listaElaboracaoNormativaConsulta;
-	
+
 	@JsonIgnore
 	@OneToMany(cascade = CascadeType.ALL, mappedBy = "elaboracaoNormativa", fetch = FetchType.EAGER)
 	private List<ElaboracaoNormativaCoAutores> listaElaboracaoNormativaCoAutor;
-	
+
 	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
 	private List<Comentario> listaComentario;
-	
+
 	@JsonIgnore
 	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, mappedBy = "elaboracaoNormativa")
 	private List<ElaboracaoNormativaTiposMarcados> listaElaboracaoNormativaTiposMarcados;
-	
+
 	@Column
 	private Comentario comentario;
-	
-	// Manifestação (por enquanto deixei na mesma entidade para evitar normalização desnecessaria)
+
+	// Manifestação (por enquanto deixei na mesma entidade para evitar
+	// normalização desnecessaria)
 	@Column
 	private Date dataManifestacao;
-	
+
 	@Column
 	@Enumerated(EnumType.ORDINAL)
 	private ElaboracaoNormativaNorma elaboracaoNormativaNorma;
-	
+
 	@JsonIgnore
 	@OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, mappedBy = "elaboracaoNormativa")
 	private Set<TagElaboracaoNormativa> tagsElaboracaoNormativa;
-	
+
 	@Column
 	private String ementaManifestacao;
-	
+
 	@Column
 	private String arquivoManifestacao;
-	
+
 	@Column
 	private Integer ano;
-	
+
 	@Column
 	private String numero;
-	
+
 	@Column
 	private String ementaPreliminar;
-	
+
 	@Column
 	private Date dataInclusaoSIDOF;
-	
+
 	@Column
 	private Date dataAssinaturaSIDOF;
-	
+
 	@ManyToOne(fetch = FetchType.EAGER)
 	private StatusSidof statusSidof;
-	
+
 	@Column
 	private String normaGeradaNumero;
-	
+
 	@Column
 	private Integer normaGeradaAno;
-	
+
 	@Column
 	private String normaGeradaLink;
-	
+
 	@Column
 	private ElaboracaoNormativaBotao elaboracaoNormativaBotao;
-	
+
 	@Column
 	@Enumerated(EnumType.ORDINAL)
 	private ElaboracaoNormativaSituacao elaboracaoNormativaSituacao;
-	
+
 	@Transient
 	private ElaboracaoNormativaConsulta elaboracaoNormativaConsulta;
-	
+
 	@Transient
 	private List<TagJSON> tags;
-	
+
 	@Transient
 	private List<Usuario> pareceristas;
-	
+
 	@Transient
 	private String origemDescricao;
-	
+
 	@Transient
 	private String situacaoDescricao;
-	
+
 	@Transient
 	private String tipoNormaDescricao;
-	
+
 	@Transient
 	private String linkSei;
-	
+
 	@Transient
 	private List<DropdownMultiselectJSON> listaOrigensSelecionadosDropdown;
-	
+
 	@Transient
 	private List<DropdownMultiselectSelecionadosJSON> listaCoAutoresSelecionadosDropdown;
-	
+
 	@Transient
-	private List<DropdownMultiselectJSON> listaTagsSelecionadosDropdown;	
-	
+	private List<DropdownMultiselectJSON> listaTagsSelecionadosDropdown;
+
 	@Transient
 	private String coAutoresDescricao;
-	
+
 	@Transient
 	private String statusSidofDescricao;
-	
+
 	@Transient
 	private String equipeDescricao;
-	
+
 	@Transient
 	private String pareceristaDescricao;
-	
+
 	@Transient
 	private String dataInclusaoSIDOFFormatada;
-	
+
 	@Transient
 	private String dataAssinaturaSIDOFFormatada;
-	
+
 	@Transient
 	private String dataMinifestacaoFormatada;
 
@@ -305,7 +308,6 @@ public class ElaboracaoNormativa implements AbstractEntity  {
 	public Usuario getParecerista() {
 		return parecerista;
 	}
-
 
 	public Date getDataManifestacao() {
 		return dataManifestacao;
@@ -363,8 +365,7 @@ public class ElaboracaoNormativa implements AbstractEntity  {
 		this.dataManifestacao = dataManifestacao;
 	}
 
-	public void setElaboracaoNormativaNorma(
-			ElaboracaoNormativaNorma elaboracaoNormativaNorma) {
+	public void setElaboracaoNormativaNorma(ElaboracaoNormativaNorma elaboracaoNormativaNorma) {
 		this.elaboracaoNormativaNorma = elaboracaoNormativaNorma;
 	}
 
@@ -372,16 +373,14 @@ public class ElaboracaoNormativa implements AbstractEntity  {
 		return listaElaboracaoNormativaConsulta;
 	}
 
-	public void setListaElaboracaoNormativaConsulta(
-			List<ElaboracaoNormativaConsulta> listaElaboracaoNormativaConsulta) {
+	public void setListaElaboracaoNormativaConsulta(List<ElaboracaoNormativaConsulta> listaElaboracaoNormativaConsulta) {
 		this.listaElaboracaoNormativaConsulta = listaElaboracaoNormativaConsulta;
 	}
 
-	public void setElaboracaoNormativaConsulta(
-			ElaboracaoNormativaConsulta elaboracaoNormativaConsulta) {
+	public void setElaboracaoNormativaConsulta(ElaboracaoNormativaConsulta elaboracaoNormativaConsulta) {
 		this.elaboracaoNormativaConsulta = elaboracaoNormativaConsulta;
 	}
-	
+
 	public String getArquivoManifestacao() {
 		return arquivoManifestacao;
 	}
@@ -389,32 +388,6 @@ public class ElaboracaoNormativa implements AbstractEntity  {
 	public void setArquivoManifestacao(String arquivoManifestacao) {
 		this.arquivoManifestacao = arquivoManifestacao;
 	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		ElaboracaoNormativa other = (ElaboracaoNormativa) obj;
-		if (id == null) {
-			if (other.id != null)
-				return false;
-		} else if (!id.equals(other.id))
-			return false;
-		return true;
-	}
-
 
 	public List<TagJSON> getTags() {
 		return tags;
@@ -428,406 +401,318 @@ public class ElaboracaoNormativa implements AbstractEntity  {
 		return tagsElaboracaoNormativa;
 	}
 
-	public void setTagsElaboracaoNormativa(
-			Set<TagElaboracaoNormativa> tagsElaboracaoNormativa) {
+	public void setTagsElaboracaoNormativa(Set<TagElaboracaoNormativa> tagsElaboracaoNormativa) {
 		this.tagsElaboracaoNormativa = tagsElaboracaoNormativa;
 	}
-
 
 	public List<Usuario> getPareceristas() {
 		return pareceristas;
 	}
 
-
 	public void setPareceristas(List<Usuario> pareceristas) {
 		this.pareceristas = pareceristas;
 	}
-		
-		
+
 	public AreaConsultada getAreaConsultada() {
 		return areaConsultada;
 	}
-
 
 	public void setAreaConsultada(AreaConsultada areaConsultada) {
 		this.areaConsultada = areaConsultada;
 	}
 
-
 	public String getValueTipo() {
-		return Objects.isNull(tipo)?"": tipo.getValue();
+		return Objects.isNull(tipo) ? "" : tipo.getValue();
 	}
-
 
 	public String getValueIdentificacao() {
-		return Objects.isNull(identificacao)?"":identificacao.getValue();
+		return Objects.isNull(identificacao) ? "" : identificacao.getValue();
 	}
-
 
 	public String getOrigemDescricao() {
 		return origemDescricao;
 	}
 
-
 	public void setOrigemDescricao(String origemDescricao) {
 		this.origemDescricao = origemDescricao;
 	}
-
 
 	public StatusSidof getStatusSidof() {
 		return statusSidof;
 	}
 
-
 	public void setStatusSidof(StatusSidof statusSidof) {
 		this.statusSidof = statusSidof;
 	}
-
 
 	public List<Comentario> getListaComentario() {
 		return listaComentario;
 	}
 
-
 	public void setListaComentario(List<Comentario> listaComentario) {
 		this.listaComentario = listaComentario;
 	}
-
 
 	public Comentario getComentario() {
 		return comentario;
 	}
 
-
 	public void setComentario(Comentario comentario) {
 		this.comentario = comentario;
 	}
-
 
 	public Integer getAno() {
 		return ano;
 	}
 
-
 	public void setAno(Integer ano) {
 		this.ano = ano;
 	}
-
 
 	public String getNumero() {
 		return numero;
 	}
 
-
 	public void setNumero(String numero) {
 		this.numero = numero;
 	}
-
 
 	public String getEmentaPreliminar() {
 		return ementaPreliminar;
 	}
 
-
 	public void setEmentaPreliminar(String ementaPreliminar) {
 		this.ementaPreliminar = ementaPreliminar;
 	}
-
 
 	public Date getDataInclusaoSIDOF() {
 		return dataInclusaoSIDOF;
 	}
 
-
 	public void setDataInclusaoSIDOF(Date dataInclusaoSIDOF) {
 		this.dataInclusaoSIDOF = dataInclusaoSIDOF;
 	}
-
 
 	public Date getDataAssinaturaSIDOF() {
 		return dataAssinaturaSIDOF;
 	}
 
-
 	public void setDataAssinaturaSIDOF(Date dataAssinaturaSIDOF) {
 		this.dataAssinaturaSIDOF = dataAssinaturaSIDOF;
 	}
-
 
 	public ElaboracaoNormativaSituacao getElaboracaoNormativaSituacao() {
 		return elaboracaoNormativaSituacao;
 	}
 
-
-	public void setElaboracaoNormativaSituacao(
-			ElaboracaoNormativaSituacao elaboracaoNormativaSituacao) {
+	public void setElaboracaoNormativaSituacao(ElaboracaoNormativaSituacao elaboracaoNormativaSituacao) {
 		this.elaboracaoNormativaSituacao = elaboracaoNormativaSituacao;
 	}
-
 
 	public ElaboracaoNormativaConsulta getElaboracaoNormativaConsulta() {
 		return elaboracaoNormativaConsulta;
 	}
 
-
 	public void setValueTipo(String valueTipo) {
 		this.valueTipo = valueTipo;
 	}
-
 
 	public void setValueIdentificacao(String valueIdentificacao) {
 		this.valueIdentificacao = valueIdentificacao;
 	}
 
-
 	public String getNormaGeradaNumero() {
 		return normaGeradaNumero;
 	}
-
 
 	public void setNormaGeradaNumero(String normaGeradaNumero) {
 		this.normaGeradaNumero = normaGeradaNumero;
 	}
 
-
 	public Integer getNormaGeradaAno() {
 		return normaGeradaAno;
 	}
-
 
 	public void setNormaGeradaAno(Integer normaGeradaAno) {
 		this.normaGeradaAno = normaGeradaAno;
 	}
 
-
 	public String getNormaGeradaLink() {
 		return normaGeradaLink;
 	}
-
 
 	public void setNormaGeradaLink(String normaGeradaLink) {
 		this.normaGeradaLink = normaGeradaLink;
 	}
 
-
 	public String getEmentaManifestacao() {
 		return ementaManifestacao;
 	}
-
 
 	public void setEmentaManifestacao(String ementaManifestacao) {
 		this.ementaManifestacao = ementaManifestacao;
 	}
 
-
 	public ElaboracaoNormativaBotao getElaboracaoNormativaBotao() {
 		return elaboracaoNormativaBotao;
 	}
 
-
-	public void setElaboracaoNormativaBotao(
-			ElaboracaoNormativaBotao elaboracaoNormativaBotao) {
+	public void setElaboracaoNormativaBotao(ElaboracaoNormativaBotao elaboracaoNormativaBotao) {
 		this.elaboracaoNormativaBotao = elaboracaoNormativaBotao;
 	}
-
 
 	public List<ElaboracaoNormativaTiposMarcados> getListaElaboracaoNormativaTiposMarcados() {
 		return listaElaboracaoNormativaTiposMarcados;
 	}
-
 
 	public void setListaElaboracaoNormativaTiposMarcados(
 			List<ElaboracaoNormativaTiposMarcados> listaElaboracaoNormativaTiposMarcados) {
 		this.listaElaboracaoNormativaTiposMarcados = listaElaboracaoNormativaTiposMarcados;
 	}
 
-
 	public List<ElaboracaoNormativaTipo> getTipos() {
 		return tipos;
 	}
-
 
 	public void setTipos(List<ElaboracaoNormativaTipo> tipos) {
 		this.tipos = tipos;
 	}
 
-
 	public List<DropdownMultiselectJSON> getListaOrigensSelecionadosDropdown() {
 		return listaOrigensSelecionadosDropdown;
 	}
 
-
-	public void setListaOrigensSelecionadosDropdown(
-			List<DropdownMultiselectJSON> listaOrigensSelecionadosDropdown) {
+	public void setListaOrigensSelecionadosDropdown(List<DropdownMultiselectJSON> listaOrigensSelecionadosDropdown) {
 		this.listaOrigensSelecionadosDropdown = listaOrigensSelecionadosDropdown;
 	}
-
 
 	public List<DropdownMultiselectSelecionadosJSON> getListaCoAutoresSelecionadosDropdown() {
 		return listaCoAutoresSelecionadosDropdown;
 	}
-
 
 	public void setListaCoAutoresSelecionadosDropdown(
 			List<DropdownMultiselectSelecionadosJSON> listaCoAutoresSelecionadosDropdown) {
 		this.listaCoAutoresSelecionadosDropdown = listaCoAutoresSelecionadosDropdown;
 	}
 
-
 	public String getCoAutoresDescricao() {
 		return coAutoresDescricao;
 	}
-
 
 	public void setCoAutoresDescricao(String coAutoresDescricao) {
 		this.coAutoresDescricao = coAutoresDescricao;
 	}
 
-
 	public String getStatusSidofDescricao() {
 		return statusSidofDescricao;
 	}
-
 
 	public void setStatusSidofDescricao(String statusSidofDescricao) {
 		this.statusSidofDescricao = statusSidofDescricao;
 	}
 
-
 	public String getEquipeDescricao() {
 		return equipeDescricao;
 	}
-
 
 	public void setEquipeDescricao(String equipeDescricao) {
 		this.equipeDescricao = equipeDescricao;
 	}
 
-
 	public String getPareceristaDescricao() {
 		return pareceristaDescricao;
 	}
-
 
 	public void setPareceristaDescricao(String pareceristaDescricao) {
 		this.pareceristaDescricao = pareceristaDescricao;
 	}
 
-
 	public List<ElaboracaoNormativaCoAutores> getListaElaboracaoNormativaCoAutor() {
 		return listaElaboracaoNormativaCoAutor;
 	}
 
-
-	public void setListaElaboracaoNormativaCoAutor(
-			List<ElaboracaoNormativaCoAutores> listaElaboracaoNormativaCoAutor) {
+	public void setListaElaboracaoNormativaCoAutor(List<ElaboracaoNormativaCoAutores> listaElaboracaoNormativaCoAutor) {
 		this.listaElaboracaoNormativaCoAutor = listaElaboracaoNormativaCoAutor;
 	}
-
 
 	public ElaboracaoNormativaSubTipo getSubTipo() {
 		return subTipo;
 	}
 
-
 	public void setSubTipo(ElaboracaoNormativaSubTipo subTipo) {
 		this.subTipo = subTipo;
 	}
-
 
 	public List<ElaboracaoNormativaSubTipo> getSubTipos() {
 		return subTipos;
 	}
 
-
 	public void setSubTipos(List<ElaboracaoNormativaSubTipo> subTipos) {
 		this.subTipos = subTipos;
 	}
-
 
 	public String getValueTipoSubTipo() {
 		return valueTipoSubTipo;
 	}
 
-
 	public void setValueTipoSubTipo(String valueTipoSubTipo) {
 		this.valueTipoSubTipo = valueTipoSubTipo;
 	}
-
 
 	public String getSituacaoDescricao() {
 		return situacaoDescricao;
 	}
 
-
 	public void setSituacaoDescricao(String situacaoDescricao) {
 		this.situacaoDescricao = situacaoDescricao;
 	}
-
 
 	public String getTipoNormaDescricao() {
 		return tipoNormaDescricao;
 	}
 
-
 	public void setTipoNormaDescricao(String tipoNormaDescricao) {
 		this.tipoNormaDescricao = tipoNormaDescricao;
 	}
-
 
 	public List<DropdownMultiselectJSON> getListaTagsSelecionadosDropdown() {
 		return listaTagsSelecionadosDropdown;
 	}
 
-
-	public void setListaTagsSelecionadosDropdown(
-			List<DropdownMultiselectJSON> listaTagsSelecionadosDropdown) {
+	public void setListaTagsSelecionadosDropdown(List<DropdownMultiselectJSON> listaTagsSelecionadosDropdown) {
 		this.listaTagsSelecionadosDropdown = listaTagsSelecionadosDropdown;
 	}
-
 
 	public String getLinkSei() {
 		return linkSei;
 	}
 
-
 	public void setLinkSei(String linkSei) {
 		this.linkSei = linkSei;
 	}
-
 
 	public String getDataInclusaoSIDOFFormatada() {
 		return dataInclusaoSIDOFFormatada;
 	}
 
-
 	public void setDataInclusaoSIDOFFormatada(String dataInclusaoSIDOFFormatada) {
 		this.dataInclusaoSIDOFFormatada = dataInclusaoSIDOFFormatada;
 	}
-
 
 	public String getDataAssinaturaSIDOFFormatada() {
 		return dataAssinaturaSIDOFFormatada;
 	}
 
-
 	public void setDataAssinaturaSIDOFFormatada(String dataAssinaturaSIDOFFormatada) {
 		this.dataAssinaturaSIDOFFormatada = dataAssinaturaSIDOFFormatada;
 	}
-
 
 	public String getDataMinifestacaoFormatada() {
 		return dataMinifestacaoFormatada;
 	}
 
-
 	public void setDataMinifestacaoFormatada(String dataMinifestacaoFormatada) {
 		this.dataMinifestacaoFormatada = dataMinifestacaoFormatada;
 	}
 
-
-
-
-
-	
 }

--- a/src/main/java/br/gov/mj/sislegis/app/model/ElaboracaoNormativaCoAutores.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/ElaboracaoNormativaCoAutores.java
@@ -9,7 +9,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
 @XmlRootElement
-public class ElaboracaoNormativaCoAutores implements AbstractEntity {
+public class ElaboracaoNormativaCoAutores extends AbstractEntity {
 
 	/**
 	 * 

--- a/src/main/java/br/gov/mj/sislegis/app/model/ElaboracaoNormativaCoAutoresPK.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/ElaboracaoNormativaCoAutoresPK.java
@@ -11,17 +11,17 @@ public class ElaboracaoNormativaCoAutoresPK implements Serializable {
 	 * 
 	 */
 	private static final long serialVersionUID = 1L;
-	
+
 	private long idElaboracaoNormativa;
 	private long idOrgao;
-	
-	public ElaboracaoNormativaCoAutoresPK(long idElaboracaoNormativa, long idOrgao){
+
+	public ElaboracaoNormativaCoAutoresPK(long idElaboracaoNormativa, long idOrgao) {
 		super();
-		this.idElaboracaoNormativa=idElaboracaoNormativa;
-		this.idOrgao=idOrgao;
+		this.idElaboracaoNormativa = idElaboracaoNormativa;
+		this.idOrgao = idOrgao;
 	}
 
-	public ElaboracaoNormativaCoAutoresPK(){
+	public ElaboracaoNormativaCoAutoresPK() {
 		super();
 	}
 
@@ -40,7 +40,7 @@ public class ElaboracaoNormativaCoAutoresPK implements Serializable {
 	public void setIdOrgao(long idOrgao) {
 		this.idOrgao = idOrgao;
 	}
-	
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
@@ -64,5 +64,5 @@ public class ElaboracaoNormativaCoAutoresPK implements Serializable {
 		if (idOrgao != other.idOrgao)
 			return false;
 		return true;
-	}	
+	}
 }

--- a/src/main/java/br/gov/mj/sislegis/app/model/ElaboracaoNormativaConsulta.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/ElaboracaoNormativaConsulta.java
@@ -17,28 +17,28 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @Entity
 @XmlRootElement
 @Table(name = "elaboracao_normativa_consulta")
-@JsonIgnoreProperties({"elaboracaoNormativa"})
-public class ElaboracaoNormativaConsulta implements AbstractEntity {
-	
+@JsonIgnoreProperties({ "elaboracaoNormativa" })
+public class ElaboracaoNormativaConsulta extends AbstractEntity {
+
 	private static final long serialVersionUID = 4338236680426826432L;
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "id", updatable = false, nullable = false)
 	private Long id;
-	
+
 	@ManyToOne
 	private ElaboracaoNormativa elaboracaoNormativa;
-	
+
 	@ManyToOne(fetch = FetchType.EAGER)
 	private AreaConsultada areaConsultada;
-	
+
 	@Column
 	private Date prazoResposta;
-	
+
 	@Column
 	private String comentario;
-	
+
 	@Column
 	private String arquivo;
 
@@ -74,31 +74,6 @@ public class ElaboracaoNormativaConsulta implements AbstractEntity {
 		this.arquivo = arquivo;
 	}
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		ElaboracaoNormativaConsulta other = (ElaboracaoNormativaConsulta) obj;
-		if (id == null) {
-			if (other.id != null)
-				return false;
-		} else if (!id.equals(other.id))
-			return false;
-		return true;
-	}
-
 	public AreaConsultada getAreaConsultada() {
 		return areaConsultada;
 	}
@@ -114,7 +89,7 @@ public class ElaboracaoNormativaConsulta implements AbstractEntity {
 	public void setPrazoResposta(Date prazoResposta) {
 		this.prazoResposta = prazoResposta;
 	}
-	
+
 	// TODO: anexo
 
 }

--- a/src/main/java/br/gov/mj/sislegis/app/model/ElaboracaoNormativaTiposMarcados.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/ElaboracaoNormativaTiposMarcados.java
@@ -17,31 +17,32 @@ import br.gov.mj.sislegis.app.enumerated.ElaboracaoNormativaTipo;
 
 @Entity
 @XmlRootElement
-public class ElaboracaoNormativaTiposMarcados implements AbstractEntity{
-	
+public class ElaboracaoNormativaTiposMarcados extends AbstractEntity {
+
 	/**
 	 * 
 	 */
 	private static final long serialVersionUID = 7722617248451501605L;
-	
-	public ElaboracaoNormativaTiposMarcados(){}
+
+	public ElaboracaoNormativaTiposMarcados() {
+	}
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "id", updatable = false, nullable = false)
 	private Long id;
-	
+
 	@ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
 	private ElaboracaoNormativa elaboracaoNormativa;
-	
+
 	@Column
 	@Enumerated(EnumType.ORDINAL)
 	private ElaboracaoNormativaTipo tipo;
-	
+
 	@Column
 	@Enumerated(EnumType.ORDINAL)
 	private ElaboracaoNormativaSubTipo subTipo;
-	
+
 	public Long getId() {
 		return id;
 	}
@@ -56,32 +57,6 @@ public class ElaboracaoNormativaTiposMarcados implements AbstractEntity{
 
 	public void setTipo(ElaboracaoNormativaTipo tipo) {
 		this.tipo = tipo;
-	}
-
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof ElaboracaoNormativaTiposMarcados)) {
-			return false;
-		}
-		ElaboracaoNormativaTiposMarcados other = (ElaboracaoNormativaTiposMarcados) obj;
-		if (id != null) {
-			if (!id.equals(other.id)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
 	}
 
 	public ElaboracaoNormativa getElaboracaoNormativa() {
@@ -99,6 +74,5 @@ public class ElaboracaoNormativaTiposMarcados implements AbstractEntity{
 	public void setSubTipo(ElaboracaoNormativaSubTipo subTipo) {
 		this.subTipo = subTipo;
 	}
-	
 
 }

--- a/src/main/java/br/gov/mj/sislegis/app/model/Encaminhamento.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/Encaminhamento.java
@@ -9,7 +9,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
 @XmlRootElement
-public class Encaminhamento implements AbstractEntity {
+public class Encaminhamento extends AbstractEntity {
 
 	private static final long serialVersionUID = -678638303472923926L;
 
@@ -27,31 +27,6 @@ public class Encaminhamento implements AbstractEntity {
 
 	public void setId(final Long id) {
 		this.id = id;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof Encaminhamento)) {
-			return false;
-		}
-		Encaminhamento other = (Encaminhamento) obj;
-		if (id != null) {
-			if (!id.equals(other.id)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
 	}
 
 	public String getNome() {

--- a/src/main/java/br/gov/mj/sislegis/app/model/EncaminhamentoProposicao.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/EncaminhamentoProposicao.java
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @Entity
 @XmlRootElement
-@JsonIgnoreProperties({"idProposicao"})
-public class EncaminhamentoProposicao implements AbstractEntity {
+@JsonIgnoreProperties({ "idProposicao" })
+public class EncaminhamentoProposicao extends AbstractEntity {
 
 	private static final long serialVersionUID = 7949894944142814382L;
 
@@ -64,31 +64,6 @@ public class EncaminhamentoProposicao implements AbstractEntity {
 
 	public void setId(Long id) {
 		this.id = id;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof EncaminhamentoProposicao)) {
-			return false;
-		}
-		EncaminhamentoProposicao other = (EncaminhamentoProposicao) obj;
-		if (id != null) {
-			if (!id.equals(other.id)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
 	}
 
 	@Override

--- a/src/main/java/br/gov/mj/sislegis/app/model/Equipe.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/Equipe.java
@@ -16,7 +16,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @Entity
 @Table(name = "equipe")
 @XmlRootElement
-public class Equipe implements AbstractEntity {
+public class Equipe extends AbstractEntity {
 
 	private static final long serialVersionUID = 8516082010865687791L;
 
@@ -27,8 +27,8 @@ public class Equipe implements AbstractEntity {
 
 	@Column
 	private String nome;
-	
-	@OneToMany(fetch = FetchType.EAGER, mappedBy = "equipe", cascade={CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
+
+	@OneToMany(fetch = FetchType.EAGER, mappedBy = "equipe", cascade = { CascadeType.PERSIST, CascadeType.MERGE }, orphanRemoval = true)
 	private Set<EquipeUsuario> listaEquipeUsuario;
 
 	public Long getId() {
@@ -38,7 +38,7 @@ public class Equipe implements AbstractEntity {
 	public void setId(final Long id) {
 		this.id = id;
 	}
-	
+
 	public String getNome() {
 		return nome;
 	}
@@ -46,38 +46,13 @@ public class Equipe implements AbstractEntity {
 	public void setNome(String nome) {
 		this.nome = nome;
 	}
-	
+
 	public Set<EquipeUsuario> getListaEquipeUsuario() {
 		return listaEquipeUsuario;
 	}
 
 	public void setListaEquipeUsuario(Set<EquipeUsuario> listaEquipeUsuario) {
 		this.listaEquipeUsuario = listaEquipeUsuario;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof Equipe)) {
-			return false;
-		}
-		Equipe other = (Equipe) obj;
-		if (id != null) {
-			if (!id.equals(other.id)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
 	}
 
 	@Override

--- a/src/main/java/br/gov/mj/sislegis/app/model/EquipeUsuario.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/EquipeUsuario.java
@@ -18,6 +18,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties({"equipe"})
 public class EquipeUsuario implements Serializable {
 	
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -6090959072309141223L;
+
 	@EmbeddedId
     private EquipeUsuarioPK id;
 	

--- a/src/main/java/br/gov/mj/sislegis/app/model/Orgao.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/Orgao.java
@@ -9,8 +9,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
 @XmlRootElement
-public class Orgao implements AbstractEntity {
-	
+public class Orgao extends AbstractEntity {
+
 	private static final long serialVersionUID = -5843916678553628190L;
 
 	@Id
@@ -18,7 +18,7 @@ public class Orgao implements AbstractEntity {
 	@Column(name = "id", updatable = false, nullable = false)
 	private Long id;
 
-	@Column(unique=true)
+	@Column(unique = true)
 	private String nome;
 
 	public Long getId() {
@@ -27,31 +27,6 @@ public class Orgao implements AbstractEntity {
 
 	public void setId(final Long id) {
 		this.id = id;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof Orgao)) {
-			return false;
-		}
-		Orgao other = (Orgao) obj;
-		if (id != null) {
-			if (!id.equals(other.id)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
 	}
 
 	public String getNome() {

--- a/src/main/java/br/gov/mj/sislegis/app/model/OrigemElaboracaoNormativa.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/OrigemElaboracaoNormativa.java
@@ -9,16 +9,16 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
 @XmlRootElement
-public class OrigemElaboracaoNormativa implements AbstractEntity {
+public class OrigemElaboracaoNormativa extends AbstractEntity {
 
 	private static final long serialVersionUID = 3437558309464749280L;
-	
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "id", updatable = false, nullable = false)
 	private Long id;
 
-	@Column(unique=true)
+	@Column(unique = true)
 	private String descricao;
 
 	public Long getId() {
@@ -27,31 +27,6 @@ public class OrigemElaboracaoNormativa implements AbstractEntity {
 
 	public void setId(final Long id) {
 		this.id = id;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof OrigemElaboracaoNormativa)) {
-			return false;
-		}
-		OrigemElaboracaoNormativa other = (OrigemElaboracaoNormativa) obj;
-		if (id != null) {
-			if (!id.equals(other.id)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
 	}
 
 	public String getDescricao() {

--- a/src/main/java/br/gov/mj/sislegis/app/model/Posicionamento.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/Posicionamento.java
@@ -9,8 +9,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
 @XmlRootElement
-public class Posicionamento implements AbstractEntity {
-	
+public class Posicionamento extends AbstractEntity {
+
 	private static final long serialVersionUID = -5843916678553628190L;
 
 	@Id
@@ -18,7 +18,7 @@ public class Posicionamento implements AbstractEntity {
 	@Column(name = "id", updatable = false, nullable = false)
 	private Long id;
 
-	@Column(unique=true)
+	@Column(unique = true)
 	private String nome;
 
 	public Long getId() {
@@ -27,31 +27,6 @@ public class Posicionamento implements AbstractEntity {
 
 	public void setId(final Long id) {
 		this.id = id;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof Posicionamento)) {
-			return false;
-		}
-		Posicionamento other = (Posicionamento) obj;
-		if (id != null) {
-			if (!id.equals(other.id)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
 	}
 
 	public String getNome() {

--- a/src/main/java/br/gov/mj/sislegis/app/model/Proposicao.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/Proposicao.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @Entity
 @XmlRootElement
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Proposicao implements AbstractEntity {
+public class Proposicao extends AbstractEntity {
 
 	private static final long serialVersionUID = 7949894944142814382L;
 
@@ -55,8 +55,8 @@ public class Proposicao implements AbstractEntity {
 	@Enumerated(EnumType.STRING)
 	@Column
 	private Origem origem;
-	
-	@Column(length=2000)
+
+	@Column(length = 2000)
 	private String resultadoASPAR;
 
 	@OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "proposicao")
@@ -71,7 +71,7 @@ public class Proposicao implements AbstractEntity {
 	@Transient
 	private String sigla;
 
-	@Column(length=2000)
+	@Column(length = 2000)
 	private String ementa;
 
 	@Column
@@ -82,7 +82,7 @@ public class Proposicao implements AbstractEntity {
 
 	@Column
 	private Posicionamento posicionamento;
-	
+
 	@ManyToOne(fetch = FetchType.EAGER)
 	private Usuario responsavel;
 
@@ -91,30 +91,25 @@ public class Proposicao implements AbstractEntity {
 
 	@Transient
 	private Set<Comentario> listaComentario = new HashSet<Comentario>();
-	
+
 	@Transient
 	private Set<EncaminhamentoProposicao> listaEncaminhamentoProposicao = new HashSet<EncaminhamentoProposicao>();
-	
+
 	@Transient
 	private Reuniao reuniao;
-	
+
 	@Column(nullable = false)
 	private boolean isFavorita;
 
 	@ManyToMany(fetch = FetchType.EAGER, mappedBy = "proposicoesFilha")
 	private Set<Proposicao> proposicoesPai;
-	
-	
+
 	@ManyToMany(fetch = FetchType.EAGER)
-	@JoinTable(name = "proposicao_proposicao", 
-	            joinColumns = { @JoinColumn(name = "proposicao_id")}, 
-	            inverseJoinColumns={@JoinColumn(name="proposicao_id_filha")}) 
+	@JoinTable(name = "proposicao_proposicao", joinColumns = { @JoinColumn(name = "proposicao_id") }, inverseJoinColumns = { @JoinColumn(name = "proposicao_id_filha") })
 	private Set<Proposicao> proposicoesFilha;
-	
+
 	@ManyToMany(fetch = FetchType.EAGER)
-	@JoinTable(name = "proposicao_elaboracao_normativa", 
-				joinColumns = { @JoinColumn(name = "proposicao_id") }, 
-				inverseJoinColumns = { @JoinColumn(name = "elaboracao_normativa_id") })
+	@JoinTable(name = "proposicao_elaboracao_normativa", joinColumns = { @JoinColumn(name = "proposicao_id") }, inverseJoinColumns = { @JoinColumn(name = "elaboracao_normativa_id") })
 	private Set<ElaboracaoNormativa> elaboracoesNormativas;
 
 	public String getSigla() {
@@ -169,7 +164,7 @@ public class Proposicao implements AbstractEntity {
 	public void setNumero(String numero) {
 		this.numero = numero;
 	}
-	
+
 	public String getEmenta() {
 		return ementa;
 	}
@@ -254,8 +249,7 @@ public class Proposicao implements AbstractEntity {
 		return listaEncaminhamentoProposicao;
 	}
 
-	public void setListaEncaminhamentoProposicao(
-			Set<EncaminhamentoProposicao> listaEncaminhamentoProposicao) {
+	public void setListaEncaminhamentoProposicao(Set<EncaminhamentoProposicao> listaEncaminhamentoProposicao) {
 		this.listaEncaminhamentoProposicao = listaEncaminhamentoProposicao;
 	}
 
@@ -290,7 +284,7 @@ public class Proposicao implements AbstractEntity {
 	public void setResultadoASPAR(String resultadoASPAR) {
 		this.resultadoASPAR = resultadoASPAR;
 	}
-	
+
 	public boolean isFavorita() {
 		return isFavorita;
 	}
@@ -314,39 +308,13 @@ public class Proposicao implements AbstractEntity {
 	public void setProposicoesFilha(Set<Proposicao> proposicoesFilha) {
 		this.proposicoesFilha = proposicoesFilha;
 	}
-	
+
 	public Set<ElaboracaoNormativa> getElaboracoesNormativas() {
 		return elaboracoesNormativas;
 	}
 
-	public void setElaboracoesNormativas(
-			Set<ElaboracaoNormativa> elaboracoesNormativas) {
+	public void setElaboracoesNormativas(Set<ElaboracaoNormativa> elaboracoesNormativas) {
 		this.elaboracoesNormativas = elaboracoesNormativas;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof Proposicao)) {
-			return false;
-		}
-		Proposicao other = (Proposicao) obj;
-		if (id != null) {
-			if (!id.equals(other.id)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
 	}
 
 	@Override

--- a/src/main/java/br/gov/mj/sislegis/app/model/Reuniao.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/Reuniao.java
@@ -18,7 +18,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
 @XmlRootElement
-public class Reuniao implements AbstractEntity {
+public class Reuniao extends AbstractEntity {
 
 	private static final long serialVersionUID = -3187796439185752162L;
 
@@ -42,31 +42,6 @@ public class Reuniao implements AbstractEntity {
 		this.id = id;
 	}
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof Reuniao)) {
-			return false;
-		}
-		Reuniao other = (Reuniao) obj;
-		if (id != null) {
-			if (!id.equals(other.id)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
-	}
-
 	public Date getData() {
 		return data;
 	}
@@ -79,8 +54,7 @@ public class Reuniao implements AbstractEntity {
 		return listaReuniaoProposicoes;
 	}
 
-	public void setListaReuniaoProposicoes(
-			Set<ReuniaoProposicao> listaReuniaoProposicoes) {
+	public void setListaReuniaoProposicoes(Set<ReuniaoProposicao> listaReuniaoProposicoes) {
 		this.listaReuniaoProposicoes = listaReuniaoProposicoes;
 	}
 

--- a/src/main/java/br/gov/mj/sislegis/app/model/ReuniaoProposicao.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/ReuniaoProposicao.java
@@ -10,7 +10,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
 @XmlRootElement
-public class ReuniaoProposicao implements AbstractEntity {
+public class ReuniaoProposicao extends AbstractEntity {
 
 	private static final long serialVersionUID = 7949894944142814382L;
 
@@ -24,10 +24,10 @@ public class ReuniaoProposicao implements AbstractEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@MapsId("idProposicao")
 	private Proposicao proposicao;
-	
+
 	@Column
 	private String siglaComissao;
-	
+
 	@Column
 	private Integer seqOrdemPauta;
 
@@ -91,25 +91,5 @@ public class ReuniaoProposicao implements AbstractEntity {
 		String result = getClass().getSimpleName() + " ";
 		return result;
 	}
-	
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof Reuniao)) {
-			return false;
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((reuniaoProposicaoPK == null) ? 0 : reuniaoProposicaoPK.hashCode());
-		return result;
-	}	
-
 
 }

--- a/src/main/java/br/gov/mj/sislegis/app/model/StatusSidof.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/StatusSidof.java
@@ -9,7 +9,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
 @XmlRootElement
-public class StatusSidof implements AbstractEntity {
+public class StatusSidof extends AbstractEntity {
 	private static final long serialVersionUID = -3187796439185752162L;
 
 	@Id
@@ -19,32 +19,6 @@ public class StatusSidof implements AbstractEntity {
 
 	@Column
 	private String descricao;
-
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof StatusSidof)) {
-			return false;
-		}
-		StatusSidof other = (StatusSidof) obj;
-		if (id != null) {
-			if (!id.equals(other.id)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
-	}
 
 	public Long getId() {
 		return id;

--- a/src/main/java/br/gov/mj/sislegis/app/model/Tag.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/Tag.java
@@ -13,50 +13,29 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
 @XmlRootElement
-public class Tag implements AbstractEntity {
-	
+public class Tag extends AbstractEntity {
+
 	private static final long serialVersionUID = 7949894944142814382L;
 
 	@Id
 	@Column(name = "id", updatable = false, nullable = false)
 	private String tag;
-	
+
 	@OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, mappedBy = "tag")
 	private Set<TagProposicao> listaTagProposicoes = new HashSet<TagProposicao>();
-	
+
 	@OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, mappedBy = "tag")
 	private Set<TagElaboracaoNormativa> listaTagElaboracaoNormativa = new HashSet<TagElaboracaoNormativa>();
 
 	@Override
 	public Number getId() {
-		// TODO Auto-generated method stub
 		return tag.hashCode();
 	}
-	
+
 	@Override
 	public String toString() {
 		String result = tag;
 		return result;
-	}
-	
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof Reuniao)) {
-			return false;
-		}
-		return true;
-	}
-
-	public int hashCode() {
-		int hashCode = 0;
-
-		if (tag != null)
-			hashCode ^= tag.hashCode();
-
-		return hashCode;
 	}
 
 	public String getTag() {
@@ -79,8 +58,7 @@ public class Tag implements AbstractEntity {
 		return listaTagElaboracaoNormativa;
 	}
 
-	public void setListaTagElaboracaoNormativa(
-			Set<TagElaboracaoNormativa> listaTagElaboracaoNormativa) {
+	public void setListaTagElaboracaoNormativa(Set<TagElaboracaoNormativa> listaTagElaboracaoNormativa) {
 		this.listaTagElaboracaoNormativa = listaTagElaboracaoNormativa;
 	}
 

--- a/src/main/java/br/gov/mj/sislegis/app/model/TagElaboracaoNormativa.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/TagElaboracaoNormativa.java
@@ -1,6 +1,5 @@
 package br.gov.mj.sislegis.app.model;
 
-
 import javax.persistence.CascadeType;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
@@ -11,17 +10,17 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
 @XmlRootElement
-public class TagElaboracaoNormativa implements AbstractEntity {
-	
+public class TagElaboracaoNormativa extends AbstractEntity {
+
 	private static final long serialVersionUID = 7949894944142814382L;
-	
+
 	@EmbeddedId
 	private TagElaboracaoNormativaPK tagElaboracaoNormativaPK;
-	
+
 	@ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
 	@MapsId("tag")
 	private Tag tag;
-	
+
 	@ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
 	@MapsId("id")
 	private ElaboracaoNormativa elaboracaoNormativa;
@@ -30,8 +29,7 @@ public class TagElaboracaoNormativa implements AbstractEntity {
 		return tagElaboracaoNormativaPK;
 	}
 
-	public void setTagElaboracaoNormativaPK(
-			TagElaboracaoNormativaPK tagElaboracaoNormativaPK) {
+	public void setTagElaboracaoNormativaPK(TagElaboracaoNormativaPK tagElaboracaoNormativaPK) {
 		this.tagElaboracaoNormativaPK = tagElaboracaoNormativaPK;
 	}
 
@@ -50,14 +48,14 @@ public class TagElaboracaoNormativa implements AbstractEntity {
 	public void setElaboracaoNormativa(ElaboracaoNormativa elaboracaoNormativa) {
 		this.elaboracaoNormativa = elaboracaoNormativa;
 	}
-	
-	
+
 	@Override
 	public String toString() {
 		String result = getClass().getSimpleName() + " ";
 		return result;
 	}
-	
+
+	// FIXME faz sentido isso? Se for reuniao.... é igual????
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) {
@@ -79,7 +77,7 @@ public class TagElaboracaoNormativa implements AbstractEntity {
 
 	@Override
 	public Number getId() {
-		// TODO Auto-generated method stub
+		// FIXME porque esse cara retorna null??
 		return null;
 	}
 }

--- a/src/main/java/br/gov/mj/sislegis/app/model/TagProposicao.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/TagProposicao.java
@@ -10,14 +10,13 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
 @XmlRootElement
-public class TagProposicao implements AbstractEntity {
-	
+public class TagProposicao extends AbstractEntity {
+
 	private static final long serialVersionUID = 7949894944142814382L;
-	
+
 	@EmbeddedId
 	private TagProposicaoPK tagProposicaoPK;
 
-	
 	@ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
 	@MapsId("tag")
 	private Tag tag;
@@ -34,7 +33,6 @@ public class TagProposicao implements AbstractEntity {
 		this.tagProposicaoPK = tagProposicaoPK;
 	}
 
-
 	public Proposicao getProposicao() {
 		return proposicao;
 	}
@@ -42,29 +40,10 @@ public class TagProposicao implements AbstractEntity {
 	public void setProposicao(Proposicao proposicao) {
 		this.proposicao = proposicao;
 	}
-	
+
 	@Override
 	public String toString() {
 		String result = getClass().getSimpleName() + " ";
-		return result;
-	}
-	
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof Reuniao)) {
-			return false;
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((tagProposicaoPK == null) ? 0 : tagProposicaoPK.hashCode());
 		return result;
 	}
 

--- a/src/main/java/br/gov/mj/sislegis/app/model/Tarefa.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/Tarefa.java
@@ -24,8 +24,8 @@ import br.gov.mj.sislegis.app.json.ProposicaoJSON;
 @Entity
 @Table(name = "tarefa")
 @XmlRootElement
-public class Tarefa implements AbstractEntity {
-	
+public class Tarefa extends AbstractEntity {
+
 	private static final long serialVersionUID = -806063711060116952L;
 
 	@Id
@@ -40,15 +40,15 @@ public class Tarefa implements AbstractEntity {
 	@Column
 	@Enumerated(EnumType.ORDINAL)
 	private TipoTarefa tipoTarefa;
-	
+
 	private boolean isFinalizada;
-	
+
 	@OneToOne(fetch = FetchType.EAGER)
 	private EncaminhamentoProposicao encaminhamentoProposicao;
 
 	@ManyToOne(fetch = FetchType.EAGER)
 	private Usuario usuario;
-	
+
 	@Transient
 	private ProposicaoJSON proposicao;
 
@@ -90,8 +90,7 @@ public class Tarefa implements AbstractEntity {
 		return encaminhamentoProposicao;
 	}
 
-	public void setEncaminhamentoProposicao(
-			EncaminhamentoProposicao encaminhamentoProposicao) {
+	public void setEncaminhamentoProposicao(EncaminhamentoProposicao encaminhamentoProposicao) {
 		this.encaminhamentoProposicao = encaminhamentoProposicao;
 	}
 
@@ -117,31 +116,6 @@ public class Tarefa implements AbstractEntity {
 
 	public void setVisualizada(boolean isVisualizada) {
 		this.isVisualizada = isVisualizada;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof Tarefa)) {
-			return false;
-		}
-		Tarefa other = (Tarefa) obj;
-		if (id != null) {
-			if (!id.equals(other.id)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
 	}
 
 }

--- a/src/main/java/br/gov/mj/sislegis/app/model/Usuario.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/Usuario.java
@@ -13,13 +13,13 @@ import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import br.gov.mj.sislegis.app.model.pautacomissao.AgendaComissao;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @Entity
 @XmlRootElement
-public class Usuario implements AbstractEntity {
+public class Usuario extends AbstractEntity {
 
 	private static final long serialVersionUID = -8092650497855683601L;
 
@@ -80,31 +80,6 @@ public class Usuario implements AbstractEntity {
 
 	public void setEmail(String email) {
 		this.email = email;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (!(obj instanceof Usuario)) {
-			return false;
-		}
-		Usuario other = (Usuario) obj;
-		if (id != null) {
-			if (!id.equals(other.id)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
 	}
 
 	@Override

--- a/src/main/java/br/gov/mj/sislegis/app/model/pautacomissao/AgendaComissao.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/pautacomissao/AgendaComissao.java
@@ -1,6 +1,5 @@
 package br.gov.mj.sislegis.app.model.pautacomissao;
 
-import java.io.Serializable;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -133,7 +132,7 @@ public class AgendaComissao extends AbstractEntity {
 
 	public Sessao getSessao(String identificadorExterno) {
 		if (sessoes != null) {
-			for (Iterator iterator = sessoes.iterator(); iterator.hasNext();) {
+			for (Iterator<Sessao> iterator = sessoes.iterator(); iterator.hasNext();) {
 				Sessao sessao = (Sessao) iterator.next();
 				if (identificadorExterno.equals(sessao.getIdentificadorExterno())) {
 					return sessao;

--- a/src/main/java/br/gov/mj/sislegis/app/model/pautacomissao/AgendaComissao.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/pautacomissao/AgendaComissao.java
@@ -53,7 +53,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 			)
 })
 //@formatter:on
-public class AgendaComissao implements Serializable, AbstractEntity {
+public class AgendaComissao extends AbstractEntity {
 	private static final long serialVersionUID = 1L;
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
@@ -141,28 +141,6 @@ public class AgendaComissao implements Serializable, AbstractEntity {
 			}
 		}
 		return null;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-
-		if (obj instanceof AgendaComissao) {
-			AgendaComissao other = (AgendaComissao) obj;
-			if (id != null) {
-				if (id.equals(other.id)) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
 	}
 
 	public void addSessao(Sessao sessaoWS) {

--- a/src/main/java/br/gov/mj/sislegis/app/model/pautacomissao/Sessao.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/pautacomissao/Sessao.java
@@ -1,6 +1,5 @@
 package br.gov.mj.sislegis.app.model.pautacomissao;
 
-import java.io.Serializable;
 import java.util.Date;
 
 import javax.persistence.Column;
@@ -21,7 +20,7 @@ import br.gov.mj.sislegis.app.model.AbstractEntity;
 
 @Entity
 @NamedQueries({ @NamedQuery(name = "getByIdExterno", query = "SELECT s FROM Sessao s where s.identificadorExterno=:idExterno") })
-public class Sessao extends AbstractEntity {
+public class Sessao extends AbstractEntity	{
 	private static final long serialVersionUID = 1L;
 	@Column
 	@Temporal(TemporalType.TIMESTAMP)

--- a/src/main/java/br/gov/mj/sislegis/app/model/pautacomissao/Sessao.java
+++ b/src/main/java/br/gov/mj/sislegis/app/model/pautacomissao/Sessao.java
@@ -17,9 +17,11 @@ import javax.persistence.NamedQuery;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
+import br.gov.mj.sislegis.app.model.AbstractEntity;
+
 @Entity
 @NamedQueries({ @NamedQuery(name = "getByIdExterno", query = "SELECT s FROM Sessao s where s.identificadorExterno=:idExterno") })
-public class Sessao implements Serializable {
+public class Sessao extends AbstractEntity {
 	private static final long serialVersionUID = 1L;
 	@Column
 	@Temporal(TemporalType.TIMESTAMP)
@@ -90,28 +92,6 @@ public class Sessao implements Serializable {
 
 	public void setAgenda(AgendaComissao agenda) {
 		this.agenda = agenda;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-
-		if (obj instanceof Sessao) {
-			Sessao other = (Sessao) obj;
-			if (id != null) {
-				if (id.equals(other.id)) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
 	}
 
 }


### PR DESCRIPTION
A implementação de equals e hashcode de todos os models estava duplicada, e em alguns casos errada (Devido ao copy and paste).
Alteramos a interface AbstractEntity para ser uma class abstrata, e subimos esses metodos.